### PR TITLE
tests: add tests to detect overkilled spans

### DIFF
--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/FailOnOverkillTraceComponentImpl.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/FailOnOverkillTraceComponentImpl.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import io.opencensus.common.Clock;
+import io.opencensus.internal.ZeroTimeClock;
+import io.opencensus.trace.Annotation;
+import io.opencensus.trace.AttributeValue;
+import io.opencensus.trace.EndSpanOptions;
+import io.opencensus.trace.Link;
+import io.opencensus.trace.Sampler;
+import io.opencensus.trace.Span;
+import io.opencensus.trace.Span.Options;
+import io.opencensus.trace.SpanBuilder;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.SpanId;
+import io.opencensus.trace.TraceComponent;
+import io.opencensus.trace.TraceId;
+import io.opencensus.trace.TraceOptions;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracestate;
+import io.opencensus.trace.config.TraceConfig;
+import io.opencensus.trace.config.TraceParams;
+import io.opencensus.trace.export.ExportComponent;
+import io.opencensus.trace.export.RunningSpanStore;
+import io.opencensus.trace.export.SampledSpanStore;
+import io.opencensus.trace.export.SpanExporter;
+import io.opencensus.trace.propagation.BinaryFormat;
+import io.opencensus.trace.propagation.PropagationComponent;
+import io.opencensus.trace.propagation.TextFormat;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Simple {@link TraceComponent} implementation that will throw an exception if a {@link Span} is ended more than once.
+ */
+public class FailOnOverkillTraceComponentImpl extends TraceComponent {
+  private static final Random RANDOM = new Random();
+  private final Tracer tracer = new TestTracer();
+  private final PropagationComponent propagationComponent = new TestPropagationComponent();
+  private final Clock clock = ZeroTimeClock.getInstance();
+  private final ExportComponent exportComponent = new TestExportComponent();
+  private final TraceConfig traceConfig = new TestTraceConfig();
+
+  public static class TestSpan extends Span {
+    @GuardedBy("this")
+    private volatile boolean ended = false;
+
+    private TestSpan(SpanContext context, EnumSet<Options> options) {
+      super(context, options);
+    }
+
+    @Override
+    public void addAnnotation(String description, Map<String, AttributeValue> attributes) {}
+
+    @Override
+    public void addAnnotation(Annotation annotation) {}
+
+    @Override
+    public void addLink(Link link) {}
+
+    @Override
+    public void end(EndSpanOptions options) {
+      synchronized (this) {
+        if (ended) {
+          throw new IllegalStateException("already ended");
+        }
+        ended = true;
+      }
+    }
+  }
+
+  public static class TestSpanBuilder extends SpanBuilder {
+    @Override
+    public SpanBuilder setSampler(Sampler sampler) {
+      return this;
+    }
+
+    @Override
+    public SpanBuilder setParentLinks(List<Span> parentLinks) {
+      return this;
+    }
+
+    @Override
+    public SpanBuilder setRecordEvents(boolean recordEvents) {
+      return this;
+    }
+
+    @Override
+    public Span startSpan() {
+      return new TestSpan(
+          SpanContext.create(
+              TraceId.generateRandomId(RANDOM),
+              SpanId.generateRandomId(RANDOM),
+              TraceOptions.builder().setIsSampled(true).build(),
+              Tracestate.builder().build()),
+          EnumSet.of(Options.RECORD_EVENTS));
+    }
+  }
+
+  public static class TestTracer extends Tracer {
+    @Override
+    public SpanBuilder spanBuilderWithExplicitParent(String spanName, Span parent) {
+      return new TestSpanBuilder();
+    }
+
+    @Override
+    public SpanBuilder spanBuilderWithRemoteParent(
+        String spanName, SpanContext remoteParentSpanContext) {
+      return new TestSpanBuilder();
+    }
+  }
+
+  public static class TestPropagationComponent extends PropagationComponent {
+    @Override
+    public BinaryFormat getBinaryFormat() {
+      return null;
+    }
+
+    @Override
+    public TextFormat getB3Format() {
+      return null;
+    }
+
+    @Override
+    public TextFormat getTraceContextFormat() {
+      return null;
+    }
+  }
+
+  public static class TestSpanExporter extends SpanExporter {
+    @Override
+    public void registerHandler(String name, Handler handler) {}
+
+    @Override
+    public void unregisterHandler(String name) {}
+  }
+
+  public static class TestExportComponent extends ExportComponent {
+    private final SpanExporter spanExporter = new TestSpanExporter();
+
+    @Override
+    public SpanExporter getSpanExporter() {
+      return spanExporter;
+    }
+
+    @Override
+    public RunningSpanStore getRunningSpanStore() {
+      return null;
+    }
+
+    @Override
+    public SampledSpanStore getSampledSpanStore() {
+      return null;
+    }
+  }
+
+  public static class TestTraceConfig extends TraceConfig {
+    private volatile TraceParams activeTraceParams = TraceParams.DEFAULT;
+
+    @Override
+    public TraceParams getActiveTraceParams() {
+      return activeTraceParams;
+    }
+
+    @Override
+    public void updateActiveTraceParams(TraceParams traceParams) {
+      this.activeTraceParams = traceParams;
+    }
+  }
+
+  @Override
+  public Tracer getTracer() {
+    return tracer;
+  }
+
+  @Override
+  public PropagationComponent getPropagationComponent() {
+    return propagationComponent;
+  }
+
+  @Override
+  public Clock getClock() {
+    return clock;
+  }
+
+  @Override
+  public ExportComponent getExportComponent() {
+    return exportComponent;
+  }
+
+  @Override
+  public TraceConfig getTraceConfig() {
+    return traceConfig;
+  }
+}

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import com.google.api.gax.grpc.testing.LocalChannelProvider;
+import com.google.cloud.NoCredentials;
+import com.google.cloud.spanner.MockSpannerServiceImpl.StatementResult;
+import com.google.cloud.spanner.TransactionRunner.TransactionCallable;
+import com.google.protobuf.ListValue;
+import com.google.spanner.v1.ResultSetMetadata;
+import com.google.spanner.v1.StructType;
+import com.google.spanner.v1.StructType.Field;
+import com.google.spanner.v1.TypeCode;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.opencensus.trace.Tracing;
+
+@RunWith(JUnit4.class)
+public class SpanTest {
+  private static final String TEST_PROJECT = "my-project";
+  private static final String TEST_INSTANCE = "my-instance";
+  private static final String TEST_DATABASE = "my-database";
+  private static MockSpannerServiceImpl mockSpanner;
+  private static Server server;
+  private static LocalChannelProvider channelProvider;
+  private static final Statement UPDATE_STATEMENT =
+      Statement.of("UPDATE FOO SET BAR=1 WHERE BAZ=2");
+  private static final Statement INVALID_UPDATE_STATEMENT =
+      Statement.of("UPDATE NON_EXISTENT_TABLE SET BAR=1 WHERE BAZ=2");
+  private static final long UPDATE_COUNT = 1L;
+  private static final Statement SELECT1 = Statement.of("SELECT 1 AS COL1");
+  private static final ResultSetMetadata SELECT1_METADATA =
+      ResultSetMetadata.newBuilder()
+          .setRowType(
+              StructType.newBuilder()
+                  .addFields(
+                      Field.newBuilder()
+                          .setName("COL1")
+                          .setType(
+                              com.google.spanner.v1.Type.newBuilder()
+                                  .setCode(TypeCode.INT64)
+                                  .build())
+                          .build())
+                  .build())
+          .build();
+  private static final com.google.spanner.v1.ResultSet SELECT1_RESULTSET =
+      com.google.spanner.v1.ResultSet.newBuilder()
+          .addRows(
+              ListValue.newBuilder()
+                  .addValues(com.google.protobuf.Value.newBuilder().setStringValue("1").build())
+                  .build())
+          .setMetadata(SELECT1_METADATA)
+          .build();
+  private Spanner spanner;
+  private DatabaseClient client;
+
+  @BeforeClass
+  public static void startStaticServer() throws Exception {
+    mockSpanner = new MockSpannerServiceImpl();
+    mockSpanner.setAbortProbability(0.0D); // We don't want any unpredictable aborted transactions.
+    mockSpanner.putStatementResult(StatementResult.update(UPDATE_STATEMENT, UPDATE_COUNT));
+    mockSpanner.putStatementResult(StatementResult.query(SELECT1, SELECT1_RESULTSET));
+    mockSpanner.putStatementResult(
+        StatementResult.exception(
+            INVALID_UPDATE_STATEMENT,
+            Status.INVALID_ARGUMENT.withDescription("invalid statement").asRuntimeException()));
+
+    String uniqueName = InProcessServerBuilder.generateName();
+    server =
+        InProcessServerBuilder.forName(uniqueName)
+            // We need to use a real executor for timeouts to occur.
+            .scheduledExecutorService(new ScheduledThreadPoolExecutor(1))
+            .addService(mockSpanner)
+            .build()
+            .start();
+    channelProvider = LocalChannelProvider.create(uniqueName);
+
+    // Use a little bit reflection to set the test tracer.
+    java.lang.reflect.Field field = Tracing.class.getDeclaredField("traceComponent");
+    field.setAccessible(true);
+    java.lang.reflect.Field modifiersField = java.lang.reflect.Field.class.getDeclaredField("modifiers");
+    modifiersField.setAccessible(true);
+    // Remove the final modifier from the 'traceComponent' field.
+    modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+    field.set(null, new FailOnOverkillTraceComponentImpl());
+  }
+
+  @AfterClass
+  public static void stopServer() throws InterruptedException {
+    server.shutdown();
+    server.awaitTermination();
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    spanner =
+        SpannerOptions.newBuilder()
+            .setProjectId(TEST_PROJECT)
+            .setChannelProvider(channelProvider)
+            .setCredentials(NoCredentials.getInstance())
+            .setSessionPoolOption(SessionPoolOptions.newBuilder().setMinSessions(0).build())
+            .build()
+            .getService();
+    client = spanner.getDatabaseClient(DatabaseId.of(TEST_PROJECT, TEST_INSTANCE, TEST_DATABASE));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    spanner.close();
+    mockSpanner.reset();
+    mockSpanner.removeAllExecutionTimes();
+  }
+
+  @Test
+  public void singleUse() {
+    try (ResultSet rs = client.singleUse().executeQuery(SELECT1)) {
+      while (rs.next()) {
+        // Just consume the result set.
+      }
+    }
+  }
+
+  @Test
+  public void multiUse() {
+    try(ReadOnlyTransaction tx = client.readOnlyTransaction()) {
+      try (ResultSet rs = tx.executeQuery(SELECT1)) {
+        while (rs.next()) {
+          // Just consume the result set.
+        }
+      }
+    }
+  }
+
+  @Test
+  public void transactionRunner() {
+    TransactionRunner runner = client.readWriteTransaction();
+    runner.run(new TransactionCallable<Void>(){
+      @Override
+      public Void run(TransactionContext transaction) throws Exception {
+        transaction.executeUpdate(UPDATE_STATEMENT);
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void transactionRunnerWithError() {
+    TransactionRunner runner = client.readWriteTransaction();
+    try {
+      runner.run(new TransactionCallable<Void>(){
+        @Override
+        public Void run(TransactionContext transaction) throws Exception {
+          transaction.executeUpdate(INVALID_UPDATE_STATEMENT);
+          return null;
+        }
+      });
+      fail("missing expected exception");
+    } catch (SpannerException e) {
+      assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ARGUMENT);
+    }
+  }
+}


### PR DESCRIPTION
Suggestion: We should add some automated testing to check that we are actually no longer overkilling the spans. The test case in this PR should enable that (and shows that there still seems to be a problem with single use read-only transactions).