### PR TITLE
fix: execute tracer tests in separate execution

### DIFF
--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -41,26 +41,26 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <reportNameSuffix>sponge_log</reportNameSuffix>
-          </configuration>
-       <executions>
-         <execution>
-           <id>default-test</id>
-           <configuration>
-            <excludedGroups>com.google.cloud.spanner.TracerTest,com.google.cloud.spanner.IntegrationTest</excludedGroups>
-           </configuration>
-         </execution>
-         <execution>
-           <id>tracer</id>
-           <goals>
-            <goal>test</goal>
-           </goals>
-           <configuration>
-            <groups>com.google.cloud.spanner.TracerTest</groups>
-           </configuration>
-         </execution>
-       </executions>
+        <configuration>
+          <reportNameSuffix>sponge_log</reportNameSuffix>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <configuration>
+              <excludedGroups>com.google.cloud.spanner.TracerTest,com.google.cloud.spanner.IntegrationTest</excludedGroups>
+            </configuration>
+          </execution>
+          <execution>
+            <id>tracer</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <groups>com.google.cloud.spanner.TracerTest</groups>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
     <pluginManagement>

--- a/google-cloud-spanner/pom.xml
+++ b/google-cloud-spanner/pom.xml
@@ -38,6 +38,30 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <reportNameSuffix>sponge_log</reportNameSuffix>
+          </configuration>
+       <executions>
+         <execution>
+           <id>default-test</id>
+           <configuration>
+            <excludedGroups>com.google.cloud.spanner.TracerTest,com.google.cloud.spanner.IntegrationTest</excludedGroups>
+           </configuration>
+         </execution>
+         <execution>
+           <id>tracer</id>
+           <goals>
+            <goal>test</goal>
+           </goals>
+           <configuration>
+            <groups>com.google.cloud.spanner.TracerTest</groups>
+           </configuration>
+         </execution>
+       </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -45,10 +69,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M4</version>
-          <configuration>
-            <excludedGroups>com.google.cloud.spanner.IntegrationTest</excludedGroups>
-            <reportNameSuffix>sponge_log</reportNameSuffix>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -60,7 +80,7 @@
               <spanner.testenv.instance>projects/gcloud-devel/instances/spanner-testing</spanner.testenv.instance>
             </systemPropertyVariables>
             <groups>com.google.cloud.spanner.IntegrationTest</groups>
-            <excludedGroups>com.google.cloud.spanner.FlakyTest</excludedGroups>
+            <excludedGroups>com.google.cloud.spanner.FlakyTest,com.google.cloud.spanner.TracerTest</excludedGroups>
             <forkedProcessTimeoutInSeconds>2400</forkedProcessTimeoutInSeconds>
           </configuration>
         </plugin>

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpanTest.java
@@ -41,10 +41,12 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
+@Category(TracerTest.class)
 public class SpanTest {
   private static final String TEST_PROJECT = "my-project";
   private static final String TEST_INSTANCE = "my-instance";

--- a/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TracerTest.java
+++ b/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TracerTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner;
+
+import org.junit.experimental.categories.Category;
+
+/**
+ * Tests marked with this {@link Category} will be executed in a separate execution with the
+ * maven-surefire plugin. The tests will be excluded from execution with the maven-failsafe plugin.
+ *
+ * <p>Separate execution prevents the injection of any custom tracing configuration from interfering
+ * with other tests, as most tracing configuration is stored in static final variables.
+ */
+public interface TracerTest {}


### PR DESCRIPTION
This should do the trick regarding the `SpanTest` test case interfering with the other test cases.

The OpenCensus configuration is all loaded into `static final` fields, and once the `SpanTest` has set this configuration through reflection, it's impossible to predict where it might have already gone, so the only solution to this is to force these tests to be executed separately from the other tests.

That being said, the reason that other test cases are failing could be an indication that there are still conditions possible that could trigger a span to be ended multiple times. It would therefore be interesting to investigate those specific failures and see if you can reproduce them in the `SpanTest` class.